### PR TITLE
add ScrollToTop component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import { ThemeProvider } from '@mui/system';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop';
 import MenuBar from './components/MenuBar';
 import HomePage from './screens/HomePage';
 import ActivitiesPage from './screens/ActivitiesPage';
@@ -51,6 +52,7 @@ const App = () => {
   return (
     <ThemeProvider theme={theme}>
       <Router>
+        <ScrollToTop />
         <MenuBar />
         <Routes>
           {/* home page */}

--- a/src/components/ScrollToTop.js
+++ b/src/components/ScrollToTop.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
React built-in issue where pages don't scroll to the top automatically after re-rendering new page.

Old:
https://user-images.githubusercontent.com/43453743/164145374-153e9c14-d69f-4bd3-8f4f-f6522581afa8.mov

New:
https://user-images.githubusercontent.com/43453743/164145421-e3b6b80c-33ba-4894-92cf-975b4d022058.mov


